### PR TITLE
Connect Overview stats to local storage cache & implement real chart data

### DIFF
--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -28,9 +28,9 @@ export default function DashboardOverview() {
   const failedTransactions = 0; // No failed transactions in blockchain data
   const pendingTransactions = 0; // No pending transactions in blockchain data
 
-  // Format revenue with $ and commas
+  // Format revenue with ETH
   const formatRevenue = (amount: number) => {
-    return `$${amount.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+    return `${amount.toLocaleString("en-US", { minimumFractionDigits: 4, maximumFractionDigits: 4 })} ETH`;
   };
 
   // Stats use cached values immediately, show T/A only if never fetched
@@ -44,7 +44,7 @@ export default function DashboardOverview() {
       direction: "up" as const,
     },
     {
-      label: "REVENUE GENERATED",
+      label: "REVENUE (ETH)",
       value: hasFetched ? formatRevenue(totalRevenue) : "T/A",
       description: hasFetched ? "TOTAL EARNINGS" : "Fetch transactions for data",
       icon: "proccesor" as keyof typeof iconMap,

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -24,7 +24,7 @@ export default function DashboardOverview() {
   // Calculate real stats from transactions (works with cached or fresh data)
   const totalTransactions = transactions.length;
   const totalRevenue = transactions.reduce((sum, tx) => sum + parseFloat(tx.amountBC || "0"), 0);
-  const successRate = totalTransactions > 0 ? 100 : 0; // All blockchain transactions are successful
+  const successRate = totalTransactions > 0 ? 100 : undefined; // All blockchain transactions are successful
   const failedTransactions = 0; // No failed transactions in blockchain data
   const pendingTransactions = 0; // No pending transactions in blockchain data
 
@@ -53,7 +53,7 @@ export default function DashboardOverview() {
     },
     {
       label: "SUCCESS RATE",
-      value: hasFetched ? `${successRate}%` : "T/A",
+      value: (hasFetched && successRate !== undefined) ? `${successRate}%` : "T/A",
       description: hasFetched ? "PAYMENT SUCCESS" : "Fetch transactions for data",
       icon: "boom" as keyof typeof iconMap,
       intent: "positive" as const,
@@ -73,7 +73,6 @@ export default function DashboardOverview() {
       intent: "neutral" as const,
     },
   ];
-  console.log("Rendering stats:", stats)
   return (
     <DashboardPageLayout
       header={{

--- a/dashboard/components/dashboard/chart/index.tsx
+++ b/dashboard/components/dashboard/chart/index.tsx
@@ -29,7 +29,7 @@ interface DashboardChartProps {
 
 const chartConfig = {
   revenue: {
-    label: "Revenue",
+    label: "Revenue (USD)",
     color: "var(--chart-1)",
   },
   transactions: {
@@ -37,7 +37,7 @@ const chartConfig = {
     color: "var(--chart-2)",
   },
   fees: {
-    label: "Fees",
+    label: "Fees (USD)",
     color: "var(--chart-3)",
   },
 } satisfies ChartConfig;
@@ -72,7 +72,7 @@ function generateChartData(transactions: TransactionEvent[], period: TimePeriod)
       if (monthDiff >= 0 && monthDiff < monthsToShow) {
         const key = txDate.toLocaleString("en-US", { month: "short" });
         if (groupedData[key]) {
-          groupedData[key].revenue += parseFloat(tx.amountBC || "0");
+          groupedData[key].revenue += parseFloat(tx.amountSC || "0");
           groupedData[key].count += 1;
         }
       }
@@ -106,7 +106,7 @@ function generateChartData(transactions: TransactionEvent[], period: TimePeriod)
       if (daysDiff >= 0 && daysDiff < daysToShow) {
         const key = dateFormat(txDate);
         if (groupedData[key]) {
-          groupedData[key].revenue += parseFloat(tx.amountBC || "0");
+          groupedData[key].revenue += parseFloat(tx.amountSC || "0");
           groupedData[key].count += 1;
         }
       }


### PR DESCRIPTION
This PR addresses the requirement to show cached statistics immediately on the Overview tab while fetching fresh data in the background. It also replaces the static mock data in the main chart with real transaction data.
Fixes #5 

Changes made:

- Instant Loading / Caching: The Overview tab now initializes state from localStorage immediately. Users won't see empty "T/A" states on page refresh anymore.
- Real Chart Data: I removed the hardcoded mock data in index.tsx. I added a generateChartData() utility that groups the actual transactions by week/month/year so the graph reflects real activity.
- Revenue Fix: I noticed the "Revenue Generated" card was hardcoded to return "T/A" in the render logic, so I fixed the calculation to sum up the actual transaction amounts.
- UX Improvements:
    - Added a small "Updating data..." banner/indicator that appears when a background fetch is happening, so the user knows the cached numbers might change.
    - Added the missing LockIcon for the Failed Transactions card.
    
Technical Implementation: 
1. page.tsx: Wired up the useTransactions loading state. The UI now gracefully handles the "stale-while-revalidate" pattern showing cached data while loading is true.

2. index.tsx (stat): Wrapped the data generation in useMemo to prevent unnecessary re-renders when toggling between timeframes. Added handling for empty states (e.g., if a user has 0 transactions, the graph renders a flat line instead of crashing).


https://github.com/user-attachments/assets/e95eb69a-cfeb-4bbe-9d29-5325d5657309



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DashboardChart shows real transaction data with week/month/year tabs, units on chart labels, and a loading indicator in the legend.
  * Real-time loading banner: "Refreshing data... Showing cached values." appears when updating while showing cached stats.
  * Lock icon added for failed transactions; labels updated to "TOTAL COUNT", "TOTAL EARNINGS", and "ALL CONFIRMED".

* **Bug Fixes**
  * Revenue sums safely, formatted with locale; success rate, failed, and pending metrics now show T/A or hide until data is available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->