### PR TITLE
Modified transactions to show only transactions involving the merchant

### DIFF
--- a/dashboard/app/transactions/page.tsx
+++ b/dashboard/app/transactions/page.tsx
@@ -160,13 +160,13 @@ export default function TransactionsPage() {
         </div>
 
         {/* Transaction Table */}
-        <div className="bg-card border border-border/40 rounded-lg overflow-hidden flex-1 flex flex-col">
+        <div className="bg-card border border-border/40 rounded-lg overflow-hidden flex flex-col">
           <div className="p-6 border-b border-border/40">
             <h2 className="text-xl font-serif">TRANSACTION ROSTER</h2>
           </div>
 
-          <div className="overflow-x-auto flex-1">
-            <table className="w-full min-w-full h-full">
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-full">
               <thead>
                 <tr className="border-b border-border/40">
                   <th className="text-left px-6 py-4 text-sm font-medium text-muted-foreground w-32">TRANSACTION ID</th>

--- a/dashboard/hooks/use-transactions.ts
+++ b/dashboard/hooks/use-transactions.ts
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react';
 import { transactionService, TransactionEvent } from '@/lib/transaction-service';
+import { useWallet } from './use-wallet';
 
 // Cache transactions in localStorage
-const CACHE_KEY = 'stablepay_transactions';
+const CACHE_KEY = 'stablepay_transactions_v2';
 const CACHE_EXPIRY = 5 * 60 * 1000; // 5 minutes
 
 interface CachedData {
@@ -11,6 +12,7 @@ interface CachedData {
 }
 
 export function useTransactions() {
+    const { walletAddress } = useWallet();
     const [transactions, setTransactions] = useState<TransactionEvent[]>([]);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -43,8 +45,7 @@ export function useTransactions() {
         try {
             setLoading(true);
             setError(null);
-            // Filter for specific merchant address: 
-            const merchantAddress = '';
+            const merchantAddress = walletAddress || '';
             const events = await transactionService.fetchStableCoinPurchases(merchantAddress);
             setTransactions(events);
             setHasFetched(true);


### PR DESCRIPTION
Fixes #33 

Changes made
- Replace hardcoded `merchantAddress = ''` by merchantAddress be walletAddress
- Refactored transactions page to allow scroll when there are many transactions
- Changed cache name so to refresh local cache



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transactions are now scoped and cached per connected wallet, with expiry and wallet-aware refresh/clear.

* **Bug Fixes**
  * Removed duplicate transaction entries via deduplication of fetched events.
  * Fetching now requires a connected wallet and avoids empty requests.
  * Fetch aggregates events for an address both as buyer and receiver to ensure completeness.

* **Style**
  * Transaction table layout adjusted so height and scrolling follow content rather than stretching.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->