### PR TITLE
Fix: Handle refs in Button component using React.forwardRef

### DIFF
--- a/dashboard/components/ui/button.tsx
+++ b/dashboard/components/ui/button.tsx
@@ -37,25 +37,24 @@ const buttonVariants = cva(
   }
 );
 
-function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ...props
-}: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean;
-  }) {
+const Button = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<"button"> &
+    VariantProps<typeof buttonVariants> & {
+      asChild?: boolean;
+    }
+>(({ className, variant, size, asChild = false, ...props }, ref) => {
   const Comp = asChild ? Slot : "button";
 
   return (
     <Comp
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
+      ref={ref}
       {...props}
     />
   );
-}
+});
+Button.displayName = "Button";
 
 export { Button, buttonVariants };


### PR DESCRIPTION
Fixes #52 

Description
This PR resolves the issue where the Button component was throwing a warning about refs not being handled properly. The warning occurred because the Button component was not wrapped in React.forwardRef, which is required for function components to accept refs.

Changes Made
- Updated the Button component to use React.forwardRef.
- Added a displayName to the Button component for better debugging and developer experience.


How to test
1. Use the Button component in a context where a ref is passed to it (e.g., inside TooltipProvider or similar).
2. Run the application.
3. Verify that the warning no longer appears in the console.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced Button component's internal architecture to support advanced integration patterns while maintaining full backward compatibility with existing implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->