### PR TITLE
Dynamic Wallet-State Binding by adding hook dependency

### DIFF
--- a/dashboard/hooks/use-transactions.ts
+++ b/dashboard/hooks/use-transactions.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { transactionService, TransactionEvent } from '@/lib/transaction-service';
+import { useWallet } from './use-wallet';
 
 // Cache transactions in localStorage
 const CACHE_KEY = 'stablepay_transactions';
@@ -11,6 +12,7 @@ interface CachedData {
 }
 
 export function useTransactions() {
+    const { walletAddress } = useWallet();
     const [transactions, setTransactions] = useState<TransactionEvent[]>([]);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -37,7 +39,7 @@ export function useTransactions() {
                 console.warn('Failed to parse cached transactions:', err);
             }
         }
-    }, []);
+    }, [walletAddress]);
 
     const fetchTransactions = async () => {
         try {

--- a/dashboard/hooks/use-transactions.ts
+++ b/dashboard/hooks/use-transactions.ts
@@ -69,7 +69,10 @@ export function useTransactions() {
                 transactions: serializableEvents as any,
                 timestamp: Date.now()
             };
-            localStorage.setItem(CACHE_KEY, JSON.stringify(cacheData));
+                if (walletAddress) {
+                    const cacheKey = `${CACHE_KEY}_${walletAddress}`;
+                    localStorage.setItem(cacheKey, JSON.stringify(cacheData));
+               }
         } catch (err) {
             console.error('Error fetching transactions:', err);
             setError(err instanceof Error ? err.message : 'Failed to fetch transactions');
@@ -77,9 +80,11 @@ export function useTransactions() {
             setLoading(false);
         }
     };
-
-    const clearCache = () => {
-        localStorage.removeItem(CACHE_KEY);
+        const clearCache = () => {
+            if (walletAddress) {
+                const cacheKey = `${CACHE_KEY}_${walletAddress}`;
+                localStorage.removeItem(cacheKey);
+            }
         setTransactions([]);
         setHasFetched(false);
     };

--- a/dashboard/hooks/use-transactions.ts
+++ b/dashboard/hooks/use-transactions.ts
@@ -18,9 +18,17 @@ export function useTransactions() {
     const [error, setError] = useState<string | null>(null);
     const [hasFetched, setHasFetched] = useState(false);
 
-    // Load cached data on mount
-    useEffect(() => {
-        const cached = localStorage.getItem(CACHE_KEY);
+       // Clear state when wallet changes
+         useEffect(() => {
+            // Reset state for new wallet context
+            setTransactions([]);
+            setHasFetched(false);
+            setError(null);
+            
+            if (!walletAddress) return;
+            
+            const cacheKey = `${CACHE_KEY}_${walletAddress}`;
+            const cached = localStorage.getItem(cacheKey);
         if (cached) {
             try {
                 const { transactions: cachedTransactions, timestamp }: CachedData = JSON.parse(cached);

--- a/dashboard/hooks/use-transactions.ts
+++ b/dashboard/hooks/use-transactions.ts
@@ -26,7 +26,7 @@ export function useTransactions() {
             setTransactions([]);
             setHasFetched(false);
             setError(null);
-            
+            setLoading(false);
             if (!walletAddress) return;
             
             const cacheKey = `${CACHE_KEY}_${walletAddress}`;

--- a/dashboard/hooks/use-transactions.ts
+++ b/dashboard/hooks/use-transactions.ts
@@ -56,10 +56,9 @@ export function useTransactions() {
         try {
             setLoading(true);
             setError(null);
-            // Filter for specific merchant address: 
-            const merchantAddress = '';
-            const events = await transactionService.fetchStableCoinPurchases(merchantAddress);
-            if (latestWalletRef.current !== requestWallet) return;
+                if (!requestWallet) throw new Error('Connect a wallet to fetch transactions');
+                const events = await transactionService.fetchStableCoinPurchases(requestWallet);
+                if (latestWalletRef.current !== requestWallet) return;
             setTransactions(events);
             setHasFetched(true);
 


### PR DESCRIPTION
### Changes made:
**Added `walletAddress` to the dependency array of the `useEffect` hook to ensure it re-runs when the wallet address changes.**

@DengreSarthak Please check it out , Closes #40 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-wallet transactions: each connected wallet now has its own cached transaction history and isolated state.

* **Bug Fixes / Reliability**
  * State now resets and cached data reloads correctly when switching wallets to prevent cross-wallet data leakage.
  * Fetches avoid applying results for a different wallet if the active wallet changes mid-request, and cache expiry prevents showing stale data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->