### PR TITLE
fix(transactions): remove duplicate close button on transaction detai…

### DIFF
--- a/dashboard/app/transactions/page.tsx
+++ b/dashboard/app/transactions/page.tsx
@@ -45,6 +45,9 @@ export default function TransactionsPage() {
   const { transactions, loading, error, hasFetched, fetchTransactions, clearCache } = useTransactions();
   const [selectedTransaction, setSelectedTransaction] = useState<any>(null)
   const [isModalOpen, setIsModalOpen] = useState(false)
+  const selectedRiskLevel = selectedTransaction
+    ? getRiskLevel(selectedTransaction.amountSC)
+    : null
   
   const transactionStats = useMemo(() => {
     return {
@@ -338,15 +341,9 @@ export default function TransactionsPage() {
                 <div className="text-sm text-muted-foreground mb-2">RISK LEVEL</div>
                 <Badge
                   variant="secondary"
-                  className={`uppercase text-sm px-3 py-1 ${
-                    selectedTransaction?.risk === "high"
-                      ? "bg-primary/20 text-primary border-primary/40"
-                      : selectedTransaction?.risk === "medium"
-                        ? "bg-muted text-muted-foreground"
-                        : "bg-red-500/20 text-red-500 border-red-500/40"
-                  }`}
+                  className={`uppercase text-sm px-3 py-1 ${selectedRiskLevel ? riskStyles[selectedRiskLevel] : ""}`}
                 >
-                  {selectedTransaction?.risk}
+                  {selectedRiskLevel}
                 </Badge>
               </div>
             </div>

--- a/dashboard/app/transactions/page.tsx
+++ b/dashboard/app/transactions/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useMemo } from "react"
-import { Bell, RefreshCw, Filter, Search, Shield, MapPin, Clock, MoreVertical, X, ExternalLink } from "lucide-react"
+import { Bell, RefreshCw, Filter, Search, Shield, MapPin, Clock, MoreVertical, ExternalLink } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
@@ -26,7 +26,15 @@ const getExplorerUrl = (chainId: number, txHash: string): string => {
 };
 
 // Helper function to get risk level based on amount
-const getRiskLevel = (amount: string) => {
+type RiskLevel = "high" | "medium" | "low"
+
+const riskStyles: Record<RiskLevel, string> = {
+  high: "bg-primary/20 text-primary border-primary/40",
+  medium: "bg-muted text-muted-foreground",
+  low: "bg-green-500/20 text-green-500 border-green-500/40",
+}
+
+const getRiskLevel = (amount: string): RiskLevel => {
   const numAmount = parseFloat(amount);
   if (numAmount > 100) return "high";
   if (numAmount > 50) return "medium";
@@ -216,7 +224,9 @@ export default function TransactionsPage() {
                     </td>
                   </tr>
                 ) : (
-                  transactions.map((transaction, index) => (
+                  transactions.map((transaction, index) => {
+                    const riskLevel = getRiskLevel(transaction.amountSC)
+                    return (
                     <tr
                       key={transaction.transactionHash}
                       onClick={() => handleRowClick(transaction)}
@@ -244,15 +254,9 @@ export default function TransactionsPage() {
                       <td className="px-6 py-4">
                         <Badge
                           variant="secondary"
-                          className={`uppercase ${
-                            getRiskLevel(transaction.amountSC) === "high"
-                              ? "bg-primary/20 text-primary border-primary/40"
-                              : getRiskLevel(transaction.amountSC) === "medium"
-                                ? "bg-muted text-muted-foreground"
-                                : "bg-green-500/20 text-green-500 border-green-500/40"
-                          }`}
+                          className={`uppercase ${riskStyles[riskLevel]}`}
                         >
-                          {getRiskLevel(transaction.amountSC)}
+                          {riskLevel}
                         </Badge>
                       </td>
                       <td className="px-6 py-4">
@@ -270,7 +274,8 @@ export default function TransactionsPage() {
                         </Button>
                       </td>
                     </tr>
-                  ))
+                    )
+                  })
                 )}
                 {/* Empty rows to fill remaining space */}
                 {Array.from({ length: 10 }).map((_, index) => (
@@ -297,14 +302,6 @@ export default function TransactionsPage() {
           <DialogHeader className="relative">
             <DialogTitle className="text-3xl font-display mb-2">{selectedTransaction?.merchant}</DialogTitle>
             <p className="text-muted-foreground font-mono">{selectedTransaction?.id}</p>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="absolute right-0 top-0"
-              onClick={() => setIsModalOpen(false)}
-            >
-              <X className="size-4" />
-            </Button>
           </DialogHeader>
 
           <div className="grid grid-cols-2 gap-8 py-6">


### PR DESCRIPTION

###  Addressed Issues:
<!-- Link the issue this PR addresses -->
Fixes #64 


###  Screenshots/Recordings:

**Before** — Two overlapping x buttons on modal:
<img width="1561" height="784" alt="564693316-a8aa2771-235f-4874-b236-f3e032b28f17" src="https://github.com/user-attachments/assets/59d1fbc4-a626-4a52-b5a9-cf10a521e13c" />


**After** — Single close button, modal behaves correctly.
<img width="1919" height="977" alt="image" src="https://github.com/user-attachments/assets/472d886a-3097-446c-9f8f-50d5c17c185b" />

###  Additional Notes:
The modal was rendering two overlapping `X` close buttons:
- One from shadcn/ui's built-in `<DialogClose />` (inside `<DialogHeader>`)
- One manually added `<Button>` with `<X />` from lucide-react

**Fix:** Removed the manual `<Button onClick={() => setIsModalOpen(false)}>` and the now-unused `X` lucide import. The Dialog primitive handles close natively.

#### Refactor — Badge Risk Level Logic
`getRiskLevel(transaction.amountSC)` was being called 3–4 times per table row inside inline ternary chains — redundant function calls on every render.

**Fix:**
- Added `RiskLevel` TypeScript type (`"high" | "medium" | "low"`) and updated `getRiskLevel` return type accordingly
- Extracted a static `riskStyles` Record map at module scope (zero re-allocation per render)
- Inside `.map()`, computed `const riskLevel = getRiskLevel(transaction.amountSC)` once per row
- Badge now uses `riskStyles[riskLevel]` — clean, readable, and performant


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.

## AI Usage Disclosure

Check one of the checkboxes below:

- [x] This PR does not contain AI-generated code at all.
- [ ] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: TODO


### ⚠️ AI Notice - Important!

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the modal's close (X) button for a cleaner header.

* **Refactor**
  * Consistent risk badges: risk label and styling are now unified across the transactions list and detail modal.
  * Improved risk determination so the selected transaction's risk is shown reliably in the modal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->